### PR TITLE
Feat: Configure environment-specific PVC sizes for RabbitMQ

### DIFF
--- a/config/deploy/demo/bindings.yaml
+++ b/config/deploy/demo/bindings.yaml
@@ -1,11 +1,11 @@
 # Bindings for a .demo. environment (adapt as needed)
 # --- Namespace and GCP Project ---
-namespace: "demo-rabbitmq"
+namespace: "demo-rabbitmq-new"
 gcp_project_id: "phoenix-development-351409" # Verify/update for demo if different from staging
 
 # --- Secret Names in GCP Secret Manager (Staging specific) ---
-erlang_cookie_secret_name: "demo-rabbitmq-erlang-cookie" # Or use staging- version if shared
-admin_password_secret_name: "demo-rabbitmq-admin-password" # Or use staging- version if shared
+erlang_cookie_secret_name: "demo-rabbitmq-erlang-cookie-new" # Or use staging- version if shared
+admin_password_secret_name: "demo-rabbitmq-admin-password-new" # Or use staging- version if shared
 
 # --- RabbitMQ Application Behavior (Staging Scale) ---
 rabbitmq_base_replicas: 2 # Initial/base number of RabbitMQ pods
@@ -24,6 +24,7 @@ rabbitmq_cpu_request: "500m"   # CPU request per RabbitMQ pod
 rabbitmq_memory_request: "1Gi" # Memory request per RabbitMQ pod
 rabbitmq_cpu_limit: "1"         # CPU limit per RabbitMQ pod (e.g., "1000m" or "1")
 rabbitmq_memory_limit: "2Gi"   # Memory limit per RabbitMQ pod
+rabbitmq_pvc_size: "10Gi"      # Persistent Volume Claim size
 
 # --- Optional & Other Configurations ---
 rabbitmq_ksa_name: "rabbitmq-ksa" # Kubernetes Service Account for RabbitMQ pods

--- a/config/deploy/feature/bindings.yaml
+++ b/config/deploy/feature/bindings.yaml
@@ -19,10 +19,10 @@ rabbitmq_image_tag: "latest" # Replace with your specific build tag
 
 # --- Resource Requests and Limits (QA Scale) ---
 # (Adjust these based on your QA environment's capacity and needs)
-rabbitmq_cpu_request: "100m"   # CPU request per RabbitMQ pod
-rabbitmq_memory_request: "256Mi" # Memory request per RabbitMQ pod
-rabbitmq_cpu_limit: "250m"      # CPU limit per RabbitMQ pod
-rabbitmq_memory_limit: "512Mi"   # Memory limit per RabbitMQ pod
+rabbitmq_cpu_request: "500m"   # CPU request per RabbitMQ pod
+rabbitmq_memory_request: "1Gi" # Memory request per RabbitMQ pod
+rabbitmq_cpu_limit: "1"      # CPU limit per RabbitMQ pod
+rabbitmq_memory_limit: "2Gi"   # Memory limit per RabbitMQ pod
 rabbitmq_pvc_size: "10Gi"      # Persistent Volume Claim size
 
 # --- Optional & Other Configurations ---

--- a/config/deploy/feature/bindings.yaml
+++ b/config/deploy/feature/bindings.yaml
@@ -1,11 +1,11 @@
 # Bindings for a .feature. environment (adapt as needed)
 # --- Namespace and GCP Project ---
-namespace: "feature-rabbitmq" # Or e.g., feature-<%= bindings["branch_name"] %>-rabbitmq
+namespace: "feature-rabbitmq-new" # Or e.g., feature-<%= bindings["branch_name"] %>-rabbitmq
 gcp_project_id: "phoenix-development-351409" # Verify/update for feature branches if different
 
 # --- Secret Names in GCP Secret Manager (QA specific) ---
-erlang_cookie_secret_name: "feature-rabbitmq-erlang-cookie" # Or use qa- version if shared
-admin_password_secret_name: "feature-rabbitmq-admin-password" # Or use qa- version if shared
+erlang_cookie_secret_name: "feature-rabbitmq-erlang-cookie-new" # Or use qa- version if shared
+admin_password_secret_name: "feature-rabbitmq-admin-password-new" # Or use qa- version if shared
 
 # --- RabbitMQ Application Behavior (QA Scale) ---
 rabbitmq_base_replicas: 1 # Initial/base number of RabbitMQ pods
@@ -23,6 +23,7 @@ rabbitmq_cpu_request: "100m"   # CPU request per RabbitMQ pod
 rabbitmq_memory_request: "256Mi" # Memory request per RabbitMQ pod
 rabbitmq_cpu_limit: "250m"      # CPU limit per RabbitMQ pod
 rabbitmq_memory_limit: "512Mi"   # Memory limit per RabbitMQ pod
+rabbitmq_pvc_size: "10Gi"      # Persistent Volume Claim size
 
 # --- Optional & Other Configurations ---
 rabbitmq_ksa_name: "rabbitmq-ksa" # Kubernetes Service Account for RabbitMQ pods

--- a/config/deploy/production/bindings.yaml
+++ b/config/deploy/production/bindings.yaml
@@ -1,0 +1,39 @@
+# Bindings for the 'production' environment
+# --- Namespace and GCP Project ---
+namespace: "production-rabbitmq-new"
+gcp_project_id: "phoenix-production-352505" # Production GCP project ID
+
+# --- Secret Names in GCP Secret Manager (Production specific) ---
+erlang_cookie_secret_name: "production-rabbitmq-erlang-cookie"
+admin_password_secret_name: "production-rabbitmq-admin-password" # For SecretProviderClass to fetch
+
+# --- RabbitMQ Application Behavior (Production Scale) ---
+rabbitmq_base_replicas: 5 # Initial/base number of RabbitMQ pods
+hpa_min_replicas: 5       # HPA: Minimum replicas
+hpa_max_replicas: 10      # HPA: Maximum replicas
+rabbitmq_admin_password_hash: "PLEASE_REPLACE_WITH_ACTUAL_PRODUCTION_ADMIN_HASH" # Generate with: docker run -it --rm rabbitmq:3.12 rabbitmqctl hash_password "your_production_password"
+
+# --- Container Image Configuration ---
+rabbitmq_image_repository: "asia-south1-docker.pkg.dev/phoenix-production-352505/custom-rabbitmq" # Update if your production image repo is different
+rabbitmq_image_tag: "latest" # Replace with your specific production build tag
+
+# --- Resource Requests and Limits (Production Scale) ---
+# (Adjust these based on your Production environment's capacity and needs)
+rabbitmq_cpu_request: "1"      # CPU request per RabbitMQ pod (e.g., "1000m")
+rabbitmq_memory_request: "2Gi" # Memory request per RabbitMQ pod
+rabbitmq_cpu_limit: "2"         # CPU limit per RabbitMQ pod (e.g., "2000m" or "2")
+rabbitmq_memory_limit: "4Gi"   # Memory limit per RabbitMQ pod
+rabbitmq_pvc_size: "20Gi"      # Persistent Volume Claim size
+
+# --- Optional & Other Configurations ---
+rabbitmq_ksa_name: "rabbitmq-ksa" # Kubernetes Service Account for RabbitMQ pods
+app_env: "production"             # Environment name, can be used for conditional logic or naming
+
+# Placeholders for rabbitmq-secret.yaml.erb (if used as a fallback or for other secrets)
+erlang_cookie_placeholder: "cHJvZHVjdGlvbi1lcmxhbmctY29va2llLXBsYWNlaG9sZGVyLWJhc2U2NA==" # echo -n "production-erlang-cookie-placeholder" | base64
+admin_password_placeholder: "cHJvZHVjdGlvbi1hZG1pbi1wYXNzd29yZC1wbGFjZWhvbGRlci1iYXNlNjQ=" # echo -n "production-admin-password-placeholder" | base64
+
+# Example for LoadBalancer annotations (if they differ for Production)
+# client_svc_annotations:
+#   cloud.google.com/load-balancer-type: "External" # Production might use an external LB
+#   networking.gke.io/load-balancer-subnet: "projects/phoenix-production-352505/regions/asia-south1/subnetworks/your-production-subnet" # Example for specific subnet

--- a/config/deploy/production/bindings.yaml
+++ b/config/deploy/production/bindings.yaml
@@ -20,9 +20,9 @@ rabbitmq_image_tag: "latest" # Replace with your specific production build tag
 # --- Resource Requests and Limits (Production Scale) ---
 # (Adjust these based on your Production environment's capacity and needs)
 rabbitmq_cpu_request: "1"      # CPU request per RabbitMQ pod (e.g., "1000m")
-rabbitmq_memory_request: "2Gi" # Memory request per RabbitMQ pod
+rabbitmq_memory_request: "1Gi" # Memory request per RabbitMQ pod
 rabbitmq_cpu_limit: "2"         # CPU limit per RabbitMQ pod (e.g., "2000m" or "2")
-rabbitmq_memory_limit: "4Gi"   # Memory limit per RabbitMQ pod
+rabbitmq_memory_limit: "2Gi"   # Memory limit per RabbitMQ pod
 rabbitmq_pvc_size: "20Gi"      # Persistent Volume Claim size
 
 # --- Optional & Other Configurations ---

--- a/config/deploy/qa/bindings.yaml
+++ b/config/deploy/qa/bindings.yaml
@@ -19,10 +19,10 @@ rabbitmq_image_tag: "latest" # Replace with your specific build tag
 
 # --- Resource Requests and Limits (QA Scale) ---
 # (Adjust these based on your QA environment's capacity and needs)
-rabbitmq_cpu_request: "250m"   # CPU request per RabbitMQ pod
-rabbitmq_memory_request: "512Mi" # Memory request per RabbitMQ pod
-rabbitmq_cpu_limit: "500m"      # CPU limit per RabbitMQ pod
-rabbitmq_memory_limit: "1Gi"   # Memory limit per RabbitMQ pod
+rabbitmq_cpu_request: "500m"   # CPU request per RabbitMQ pod
+rabbitmq_memory_request: "1Gi" # Memory request per RabbitMQ pod
+rabbitmq_cpu_limit: "1"      # CPU limit per RabbitMQ pod
+rabbitmq_memory_limit: "2Gi"   # Memory limit per RabbitMQ pod
 rabbitmq_pvc_size: "10Gi"      # Persistent Volume Claim size
 
 # --- Optional & Other Configurations ---

--- a/config/deploy/qa/bindings.yaml
+++ b/config/deploy/qa/bindings.yaml
@@ -23,6 +23,7 @@ rabbitmq_cpu_request: "250m"   # CPU request per RabbitMQ pod
 rabbitmq_memory_request: "512Mi" # Memory request per RabbitMQ pod
 rabbitmq_cpu_limit: "500m"      # CPU limit per RabbitMQ pod
 rabbitmq_memory_limit: "1Gi"   # Memory limit per RabbitMQ pod
+rabbitmq_pvc_size: "10Gi"      # Persistent Volume Claim size
 
 # --- Optional & Other Configurations ---
 rabbitmq_ksa_name: "rabbitmq-ksa" # Kubernetes Service Account for RabbitMQ pods

--- a/config/deploy/staging/bindings.yaml
+++ b/config/deploy/staging/bindings.yaml
@@ -23,6 +23,7 @@ rabbitmq_cpu_request: "500m"   # CPU request per RabbitMQ pod
 rabbitmq_memory_request: "1Gi" # Memory request per RabbitMQ pod
 rabbitmq_cpu_limit: "1"         # CPU limit per RabbitMQ pod (e.g., "1000m" or "1")
 rabbitmq_memory_limit: "2Gi"   # Memory limit per RabbitMQ pod
+rabbitmq_pvc_size: "10Gi"      # Persistent Volume Claim size
 
 # --- Optional & Other Configurations ---
 rabbitmq_ksa_name: "rabbitmq-ksa" # Kubernetes Service Account for RabbitMQ pods

--- a/config/deploy/testing/bindings.yaml
+++ b/config/deploy/testing/bindings.yaml
@@ -19,10 +19,10 @@ rabbitmq_image_tag: "latest" # Replace with your specific build tag
 
 # --- Resource Requests and Limits (Testing Scale - same as QA for now) ---
 # (Adjust these based on your Testing environment's capacity and needs)
-rabbitmq_cpu_request: "250m"   # CPU request per RabbitMQ pod
-rabbitmq_memory_request: "512Mi" # Memory request per RabbitMQ pod
-rabbitmq_cpu_limit: "500m"      # CPU limit per RabbitMQ pod
-rabbitmq_memory_limit: "1Gi"   # Memory limit per RabbitMQ pod
+rabbitmq_cpu_request: "500m"   # CPU request per RabbitMQ pod
+rabbitmq_memory_request: "1Gi" # Memory request per RabbitMQ pod
+rabbitmq_cpu_limit: "1"      # CPU limit per RabbitMQ pod
+rabbitmq_memory_limit: "2Gi"   # Memory limit per RabbitMQ pod
 rabbitmq_pvc_size: "10Gi"      # Persistent Volume Claim size
 
 # --- Optional & Other Configurations ---

--- a/config/deploy/testing/bindings.yaml
+++ b/config/deploy/testing/bindings.yaml
@@ -1,0 +1,39 @@
+# Bindings for the 'testing' environment
+# --- Namespace and GCP Project ---
+namespace: "testing-rabbitmq-new"
+gcp_project_id: "phoenix-development-351409" # Verify/update if different for testing
+
+# --- Secret Names in GCP Secret Manager (Testing specific) ---
+erlang_cookie_secret_name: "testing-rabbitmq-erlang-cookie"
+admin_password_secret_name: "testing-rabbitmq-admin-password" # For SecretProviderClass to fetch
+
+# --- RabbitMQ Application Behavior (Testing Scale - same as QA for now) ---
+rabbitmq_base_replicas: 2 # Initial/base number of RabbitMQ pods
+hpa_min_replicas: 2       # HPA: Minimum replicas
+hpa_max_replicas: 4       # HPA: Maximum replicas
+rabbitmq_admin_password_hash: "PLEASE_REPLACE_WITH_ACTUAL_TESTING_ADMIN_HASH" # Generate with: docker run -it --rm rabbitmq:3.12 rabbitmqctl hash_password "your_testing_password"
+
+# --- Container Image Configuration ---
+rabbitmq_image_repository: "asia-south1-docker.pkg.dev/phoenix-development-351409/custom-rabbitmq"
+rabbitmq_image_tag: "latest" # Replace with your specific build tag
+
+# --- Resource Requests and Limits (Testing Scale - same as QA for now) ---
+# (Adjust these based on your Testing environment's capacity and needs)
+rabbitmq_cpu_request: "250m"   # CPU request per RabbitMQ pod
+rabbitmq_memory_request: "512Mi" # Memory request per RabbitMQ pod
+rabbitmq_cpu_limit: "500m"      # CPU limit per RabbitMQ pod
+rabbitmq_memory_limit: "1Gi"   # Memory limit per RabbitMQ pod
+rabbitmq_pvc_size: "10Gi"      # Persistent Volume Claim size
+
+# --- Optional & Other Configurations ---
+rabbitmq_ksa_name: "rabbitmq-ksa" # Kubernetes Service Account for RabbitMQ pods
+app_env: "testing"                # Environment name, can be used for conditional logic or naming
+
+# Placeholders for rabbitmq-secret.yaml.erb (if used as a fallback or for other secrets)
+erlang_cookie_placeholder: "dGVzdGluZy1lcmxhbmctY29va2llLXBsYWNlaG9sZGVyLWJhc2U2NA==" # echo -n "testing-erlang-cookie-placeholder" | base64
+admin_password_placeholder: "dGVzdGluZy1hZG1pbi1wYXNzd29yZC1wbGFjZWhvbGRlci1iYXNlNjQ=" # echo -n "testing-admin-password-placeholder" | base64
+
+# Example for LoadBalancer annotations (if they differ for Testing)
+# client_svc_annotations:
+#   cloud.google.com/load-balancer-type: "Internal"
+#   networking.gke.io/load-balancer-type: "Internal"

--- a/kubernetes/rabbitmq/templates/rabbitmq-statefulset.yaml.erb
+++ b/kubernetes/rabbitmq/templates/rabbitmq-statefulset.yaml.erb
@@ -177,5 +177,5 @@ spec:
       accessModes: [ "ReadWriteOnce" ] # Suitable for most cloud provider block storage
       resources:
         requests:
-          storage: 10Gi # Adjust storage size as needed
+          storage: <%= bindings["rabbitmq_pvc_size"] || "10Gi" %> # Default to 10Gi if not specified
       # storageClassName: "standard" # Uncomment and specify if you need a specific storage class


### PR DESCRIPTION
- Added `rabbitmq_pvc_size` to all bindings.yaml files (20Gi for prod, 10Gi for others).
- Updated RabbitMQ StatefulSet template to use this new binding for PVC storage requests.